### PR TITLE
ci: update dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,17 @@ updates:
     directory: "/"
     schedule:
       interval: cron
-      cronjob: "0 18 * * *"
+      cronjob: "0 18 * * 1"
       timezone: "Europe/Tallinn"
     groups:
       all-updates:
         applies-to: version-updates
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: cron
+      cronjob: "0 18 * * 1"
+      timezone: "Europe/Tallinn"
 


### PR DESCRIPTION
## Changes Made 🔧

This PR updates the Dependabot configuration to optimize the update frequency and add GitHub Actions ecosystem management.

### What's Changed 📋
- **npm packages**: Changed from daily to weekly updates (Mondays at 18:00)
- **GitHub Actions**: Added ecosystem with weekly schedule
- **Timezone**: Both configurations use Europe/Tallinn timezone
- **Grouping**: All npm updates are grouped together to reduce PR noise

### Benefits 🎯
- 📉 Reduces notification spam from daily updates
- 🔒 Maintains security by checking weekly
- 🤖 Adds GitHub Actions dependency management
- 📦 Groups related updates together

### Schedule Details 📅
Both ecosystems now run:
- **Day**: Every Monday (day 1 of the week)
- **Time**: 18:00 Europe/Tallinn
- **Cron**: `0 18 * * 1`

This provides a good balance between staying updated and avoiding excessive notifications.